### PR TITLE
use ansible_* vars in place of ansible_ssh_*

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,8 +1,8 @@
 ---
 
-ansible_ssh_user: "{{ host_user }}"
+ansible_user: "{{ host_user }}"
 ansible_become_pass: "{{ host_password }}"
 default_sshd_port: 1022
-ansible_ssh_port: "{{ default_sshd_port }}"
+ansible_port: "{{ default_sshd_port }}"
 host_admin_user: root
 ansible_python_interpreter: /usr/bin/python3

--- a/group_vars/gatewayed
+++ b/group_vars/gatewayed
@@ -1,3 +1,3 @@
 ---
 
-ansible_ssh_common_args: '-o ProxyCommand="ssh -p {{ ansible_sshd_port }} -q {{ hostvars["BackupHost1"].host_user }}@{{ hostvars["BackupHost1"].ansible_ssh_host }} nc %h %p"'
+ansible_ssh_common_args: '-o ProxyCommand="ssh -p {{ ansible_port }} -q {{ hostvars["BackupHost1"].host_user }}@{{ hostvars["BackupHost1"].ansible_host }} nc %h %p"'

--- a/host_vars/Template_Server
+++ b/host_vars/Template_Server
@@ -1,6 +1,6 @@
 ## Ansible configuration for connecting to remote host
 # IP address
-ansible_ssh_host: "{{ SERVER_srv_ip }}"
+ansible_host: "{{ SERVER_srv_ip }}"
 # User
 host_user: "{{ SERVER_srv_user }}"
 # User password

--- a/initial_playbook.yml
+++ b/initial_playbook.yml
@@ -7,9 +7,9 @@
   - { role: raw_server, tags: raw }
   vars:
   - { ansible_become_pass: "{{ host_admin_password }}"}
-  - { ansible_ssh_user: "{{ host_admin_user }}" }
-  - { ansible_ssh_pass: "{{ host_admin_password }}" }
-  - { ansible_ssh_port: 22 }
+  - { ansible_user: "{{ host_admin_user }}" }
+  - { ansible_password: "{{ host_admin_password }}" }
+  - { ansible_port: 22 }
   - { ansible_connection: paramiko }
 
 - hosts: all
@@ -19,8 +19,8 @@
   - { role: init_server, tags: init }
   vars:
   - { ansible_become_pass: "{{ host_admin_password }}"}
-  - { ansible_ssh_user: "{{ host_admin_user }}" }
-  - { ansible_ssh_pass: "{{ host_admin_password }}" }
-  - { ansible_ssh_port: 22 }
+  - { ansible_user: "{{ host_admin_user }}" }
+  - { ansible_password: "{{ host_admin_password }}" }
+  - { ansible_port: 22 }
   - { ansible_connection: paramiko }
   - { initial_playbook: true }

--- a/roles/docker_nagios/templates/vps.cfg.j2
+++ b/roles/docker_nagios/templates/vps.cfg.j2
@@ -13,7 +13,7 @@ define host{
         use                     linux-server
         host_name               {{ host }}
         alias                   {{ host }}
-        address                 {{ hostvars[host].ansible_ssh_host }}
+        address                 {{ hostvars[host].ansible_host }}
         }
 
 {% endif %}
@@ -26,7 +26,7 @@ define host{
 {% if hostvars[host].odoo_prod is defined %}
         address                 {{ hostvars[host].odoo_prod.url }}
 {% else %}
-        address                 {{ hostvars[host].ansible_ssh_host }}
+        address                 {{ hostvars[host].ansible_host }}
 {% endif %}
         }
 
@@ -181,7 +181,7 @@ define service{
         use                             generic-service
         host_name                       {{ groups['all'] | map('extract', hostvars, ['inventory_hostname']) | sort | join(',') }}
         service_description             SSH
-        check_command                   check_ssh_port!{{ ansible_ssh_port }}
+        check_command                   check_ssh_port!{{ ansible_port }}
         }
 
 # FAIL2BAN

--- a/roles/filebeat/templates/filebeat.yml.j2
+++ b/roles/filebeat/templates/filebeat.yml.j2
@@ -24,7 +24,7 @@ filebeat.autodiscover:
 # ------------------------------ Logstash Output -------------------------------
 output.logstash:
   # The Logstash hosts
-  hosts: ["{{ hostvars['Filament_Dedicated'].ansible_ssh_host }}:{{ logstash_port }}"]
+  hosts: ["{{ hostvars['Filament_Dedicated'].ansible_host }}:{{ logstash_port }}"]
 
   # Set gzip compression level.
   compression_level: 3

--- a/roles/init_server/templates/collect_installed_packages_facts_Debian.sh.j2
+++ b/roles/init_server/templates/collect_installed_packages_facts_Debian.sh.j2
@@ -22,7 +22,7 @@ fi
 cp $file $latest_file
 chmod 644 $file $latest_file
 {% if inventory_hostname not in groups.backup_server %}
-sftp -P {{ ansible_ssh_port }} -o IdentityFile=/home/{{ host_user }}/.ssh/id_ed25519 {{ backup_sftp_user }}@{{ hostvars['Server_Backup'].ansible_ssh_host }} << COMMANDS
+sftp -P {{ ansible_port }} -o IdentityFile=/home/{{ host_user }}/.ssh/id_ed25519 {{ backup_sftp_user }}@{{ hostvars['Server_Backup'].ansible_host }} << COMMANDS
 put $file {{ inventory_hostname|lower }}/
 quit
 COMMANDS

--- a/roles/init_server/templates/collect_installed_packages_facts_RedHat.sh.j2
+++ b/roles/init_server/templates/collect_installed_packages_facts_RedHat.sh.j2
@@ -22,7 +22,7 @@ fi
 cp $file $latest_file
 chmod 644 $file $latest_file
 {% if inventory_hostname not in groups.backup_server %}
-sftp -P {{ ansible_ssh_port }} -o IdentityFile=/home/{{ host_user }}/.ssh/id_ed25519 {{ backup_sftp_user }}@{{ hostvars['Server_Backup'].ansible_ssh_host }} << COMMANDS
+sftp -P {{ ansible_port }} -o IdentityFile=/home/{{ host_user }}/.ssh/id_ed25519 {{ backup_sftp_user }}@{{ hostvars['Server_Backup'].ansible_host }} << COMMANDS
 put $file {{ inventory_hostname|lower }}/
 quit
 COMMANDS

--- a/roles/iptables/templates/iptables.conf.j2
+++ b/roles/iptables/templates/iptables.conf.j2
@@ -11,7 +11,7 @@
 ## DOCKER-USER chain
 # Autoriser les logs entrants des serveurs en maintenance
 {% for host in groups.maintenance_contract %}
--A DOCKER-USER -s {{ hostvars[host].ansible_ssh_host }} -p tcp -m tcp --dport {{ logstash_port }} -m state --state NEW,ESTABLISHED -j ACCEPT
+-A DOCKER-USER -s {{ hostvars[host].ansible_host }} -p tcp -m tcp --dport {{ logstash_port }} -m state --state NEW,ESTABLISHED -j ACCEPT
 {% endfor %}
 -A DOCKER-USER -p tcp -m tcp --dport {{ logstash_port }} -j LOGGING
 {% endif %}
@@ -26,7 +26,7 @@
 -A INPUT -p icmp --icmp-type echo-reply -j ACCEPT
 {% endif %}
 # SSH
--A INPUT -p tcp -m tcp --dport {{ ansible_ssh_port }} -j ACCEPT
+-A INPUT -p tcp -m tcp --dport {{ ansible_port }} -j ACCEPT
 # WEB
 {% if nginx_enabled is defined %}
 -A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
@@ -42,7 +42,7 @@
 -A INPUT -p udp -m udp --dport 68 -j ACCEPT
 # NRPE
 {% for host in groups.docker_nagios %}
--A INPUT -s {{ hostvars[host].ansible_ssh_host }} -p tcp -m tcp --dport 5666 -m state --state NEW,ESTABLISHED -j ACCEPT
+-A INPUT -s {{ hostvars[host].ansible_host }} -p tcp -m tcp --dport 5666 -m state --state NEW,ESTABLISHED -j ACCEPT
 {% endfor %}
 {% if inventory_hostname in groups.docker_nagios %}
 -A INPUT -s 192.168.239.0/24 -p tcp -m tcp --dport 5666 -m state --state NEW,ESTABLISHED -j ACCEPT
@@ -60,7 +60,7 @@
 -A OUTPUT -p icmp --icmp-type echo-request -j ACCEPT
 {% endif %}
 # SSH
--A OUTPUT -p tcp -m tcp --dport {{ ansible_ssh_port }} -j ACCEPT
+-A OUTPUT -p tcp -m tcp --dport {{ ansible_port }} -j ACCEPT
 # WEB
 -A OUTPUT -p tcp -m tcp --dport 80 -j ACCEPT
 -A OUTPUT -p tcp -m tcp --dport 443 -j ACCEPT
@@ -82,7 +82,7 @@
 {% if inventory_hostname in groups.maintenance_contract %}
 # Log Server
 {% for host in groups.docker_elk %}
--A OUTPUT -d {{ hostvars[host].ansible_ssh_host }} -p tcp -m tcp --dport {{ logstash_port }} -j ACCEPT
+-A OUTPUT -d {{ hostvars[host].ansible_host }} -p tcp -m tcp --dport {{ logstash_port }} -j ACCEPT
 {% endfor %}
 {% endif %}
 {% if inventory_hostname in groups.odoo_server %}

--- a/roles/iptables/templates/jail.Ubuntu16.j2
+++ b/roles/iptables/templates/jail.Ubuntu16.j2
@@ -185,7 +185,7 @@ action = %(action_)s
 
 [sshd]
 enabled = true
-port    = {{ ansible_ssh_port }}
+port    = {{ ansible_port }}
 logpath = %(sshd_log)s
 
 
@@ -194,7 +194,7 @@ logpath = %(sshd_log)s
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
 enabled = true
-port    = {{ ansible_ssh_port }}
+port    = {{ ansible_port }}
 logpath = %(sshd_log)s
 
 

--- a/roles/iptables/templates/jail.Ubuntu18.j2
+++ b/roles/iptables/templates/jail.Ubuntu18.j2
@@ -210,7 +210,7 @@ backend = systemd
 enabled = true
 logpath = /var/log/auth.log
 mode    = aggressive
-port    = {{ ansible_ssh_port }}
+port    = {{ ansible_port }}
 
 
 # Jail for more extended banning of persistent abusers

--- a/roles/iptables/templates/jail.Ubuntu20.j2
+++ b/roles/iptables/templates/jail.Ubuntu20.j2
@@ -88,7 +88,7 @@ before = paths-debian.conf
 # "ignoreip" can be a list of IP addresses, CIDR masks or DNS hosts. Fail2ban
 # will not ban a host which matches an address in this list. Several addresses
 # can be defined using space (and/or comma) separator.
-ignoreip = 127.0.0.1/8{% if inventory_hostname in groups.docker %} 172.16.0.0/12 192.168.0.0/16{% endif %}{% for host in groups.docker_nagios %} {{ hostvars[host].ansible_ssh_host }}/32{% endfor %}
+ignoreip = 127.0.0.1/8{% if inventory_hostname in groups.docker %} 172.16.0.0/12 192.168.0.0/16{% endif %}{% for host in groups.docker_nagios %} {{ hostvars[host].ansible_host }}/32{% endfor %}
 
 # External command that will take an tagged arguments to ignore, e.g. <ip>,
 # and return true if the IP is to be ignored. False otherwise.
@@ -280,7 +280,7 @@ backend = systemd
 enabled = true
 logpath = /var/log/auth.log
 mode    = aggressive
-port    = {{ ansible_ssh_port }}
+port    = {{ ansible_port }}
 
 
 # Jail for more extended banning of persistent abusers

--- a/roles/nagios/templates/localhost.cfg.j2
+++ b/roles/nagios/templates/localhost.cfg.j2
@@ -116,7 +116,7 @@ define service{
         use                             generic-service
         host_name                       {{ inventory_hostname }}
         service_description             SSH
-	check_command			check_ssh_port!{{ ansible_ssh_port }}
+	check_command			check_ssh_port!{{ ansible_port }}
         }
 
 

--- a/roles/nagios/templates/serveurs-odoo.cfg.j2
+++ b/roles/nagios/templates/serveurs-odoo.cfg.j2
@@ -12,7 +12,7 @@ define host{
         use                     linux-server            
         host_name               {{ host }} 
         alias                   {{ host }}
-        address                 {{ hostvars[host].ansible_ssh_host }}
+        address                 {{ hostvars[host].ansible_host }}
         }
 
 {% endfor %}
@@ -134,7 +134,7 @@ define service{
         use                             generic-service
         host_name                       {{ groups['all'] | difference(inventory_hostname) | map('extract', hostvars, ['inventory_hostname']) | join(',') }}
         service_description             SSH
-        check_command                   check_ssh_port!{{ ansible_ssh_port }}
+        check_command                   check_ssh_port!{{ ansible_port }}
         }
 
 # FAIL2BAN

--- a/roles/nagios_nrpe/templates/nrpe.cfg.j2
+++ b/roles/nagios_nrpe/templates/nrpe.cfg.j2
@@ -1,8 +1,8 @@
 allow_bash_command_substitution=0
 {% if inventory_hostname in groups.docker_nagios %}
-allowed_hosts={{ groups.docker_nagios | map('extract', hostvars, ['ansible_ssh_host']) | join(',') }},192.168.239.2,127.0.0.1
+allowed_hosts={{ groups.docker_nagios | map('extract', hostvars, ['ansible_host']) | join(',') }},192.168.239.2,127.0.0.1
 {% else %}
-allowed_hosts={{ groups.docker_nagios | map('extract', hostvars, ['ansible_ssh_host']) | join(',') }},127.0.0.1
+allowed_hosts={{ groups.docker_nagios | map('extract', hostvars, ['ansible_host']) | join(',') }},127.0.0.1
 {% endif %}
 command_timeout=60
 connection_timeout=300


### PR DESCRIPTION
Hello,

I replaced some `ansible_ssh_* ` variables by `ansible_*` vars.

According to https://github.com/geerlingguy/ansible-for-devops/issues/230 and to my tests (on Ansible 2.10), these variables have been deprecated.

It means that you have to define new variables in inventory if you don't want your playbooks to fail even if you use default value (for example:  `ansible_port: 22`)

I only changed files in current repository, there is certainly some changes to handle in roles linked through submodules.